### PR TITLE
Issue 3 add component labels

### DIFF
--- a/example/js/LabelsExample.jsx
+++ b/example/js/LabelsExample.jsx
@@ -1,0 +1,42 @@
+/* eslint react/no-multi-comp: 0, react/prop-types: 0 */
+
+import React from 'react';
+import { Label } from 'lib/index';
+
+class LabelsExample extends React.Component {
+  render() {
+    return (
+      <div>
+        <h3>Labels</h3>
+        <hr/>
+        <p>Scale to parent</p>
+        <h1>Heading <Label>New</Label></h1>
+        <h2>Heading <Label>New</Label></h2>
+        <h3>Heading <Label>New</Label></h3>
+        <h4>Heading <Label>New</Label></h4>
+        <h5>Heading <Label>New</Label></h5>
+        <h6>Heading <Label>New</Label></h6>
+        <p>Variations</p>
+        <p>
+          <Label>default</Label>&nbsp;
+          <Label color="primary">primary</Label>&nbsp;
+          <Label color="success">success</Label>&nbsp;
+          <Label color="info">info</Label>&nbsp;
+          <Label color="warning">warning</Label>&nbsp;
+          <Label color="danger">danger</Label>
+        </p>
+        <p>Pills</p>
+        <p>
+          <Label color="default" pill>default</Label>&nbsp;
+          <Label color="primary" pill>primary</Label>&nbsp;
+          <Label color="success" pill>success</Label>&nbsp;
+          <Label color="info" pill>info</Label>&nbsp;
+          <Label color="warning" pill>warning</Label>&nbsp;
+          <Label color="danger" pill>danger</Label>
+        </p>
+      </div>
+    );
+  }
+}
+
+export default LabelsExample;

--- a/example/js/Layout.jsx
+++ b/example/js/Layout.jsx
@@ -3,6 +3,7 @@ import ButtonsExample from './ButtonsExample';
 import DropdownsExample from './DropdownsExample';
 import TetherExample from './TetherExample';
 import TooltipExample from './TooltipExample';
+import LabelsExample from './LabelsExample';
 
 class Layout extends React.Component {
   render() {
@@ -17,6 +18,7 @@ class Layout extends React.Component {
             <DropdownsExample/>
             <TetherExample/>
             <TooltipExample/>
+            <LabelsExample/>
           </div>
         </div>
       </div>

--- a/lib/Label.jsx
+++ b/lib/Label.jsx
@@ -1,0 +1,47 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+const propTypes = {
+  color: PropTypes.string,
+  pill: PropTypes.bool
+};
+
+const defaultProps = {
+  color: 'default',
+  pill: false
+};
+
+class Label extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    const {
+      children,
+      className,
+      color,
+      pill,
+      ...attributes
+    } = this.props;
+
+    const classes = classNames(
+      className,
+      'label',
+      'label-' + color,
+      pill ? 'label-pill' : false
+    );
+
+    return (
+      <span {...attributes}
+        className={classes}>
+        {children}
+      </span>
+    );
+  }
+}
+
+Label.propTypes = propTypes;
+Label.defaultProps = defaultProps;
+
+export default Label;

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ import Dropdown from './Dropdown';
 import DropdownItem from './DropdownItem';
 import DropdownMenu from './DropdownMenu';
 import DropdownToggle from './DropdownToggle';
+import Label from './Label';
 import TetherContent from './TetherContent';
 import Tooltip from './Tooltip';
 
@@ -18,6 +19,7 @@ export {
   DropdownItem,
   DropdownMenu,
   DropdownToggle,
+  Label,
   TetherContent,
   Tooltip
 };

--- a/test/Label.spec.js
+++ b/test/Label.spec.js
@@ -1,0 +1,24 @@
+/* eslint react/no-multi-comp: 0, react/prop-types: 0 */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Label } from '../lib';
+
+describe('Label', () => {
+  it('should render children', () => {
+    const wrapper = shallow(<Label>Yo!</Label>);
+
+    expect(wrapper.text()).toBe('Yo!');
+  });
+
+  it('should render labels with default color', () => {
+    const wrapper = shallow(<Label>Default Label</Label>);
+
+    expect(wrapper.hasClass('label-default')).toBe(true);
+  });
+
+  it('should render Labels with other colors', () => {
+    const wrapper = shallow(<Label color="danger">Danger Label</Label>);
+
+    expect(wrapper.hasClass('label-danger')).toBe(true);
+  });
+});


### PR DESCRIPTION
The bs4 label component has no sizing options. The size depends on the parent, ese.

![](http://ab7486c5426195071630-014bba76100c913cbaad66af8ec4a497.r87.cf1.rackcdn.com/TinyGrab%20Screen%20Shot%203-9-16,%209.57.11%20PM.png)

Fixes #3 
